### PR TITLE
Fix test indexer regex to handle namespaced item tags

### DIFF
--- a/src/routes/indexers.ts
+++ b/src/routes/indexers.ts
@@ -166,7 +166,7 @@ export function createIndexerRoutes(deps: IndexerDeps): Router {
 
       // Parse XML to extract titles from within <item> tags only
       const titles: string[] = [];
-      const itemMatches = text.matchAll(/<item>([\s\S]*?)<\/item>/g);
+      const itemMatches = text.matchAll(/<item[^>]*>([\s\S]*?)<\/item>/g);
 
       for (const itemMatch of itemMatches) {
         const itemContent = itemMatch[1];
@@ -177,7 +177,7 @@ export function createIndexerRoutes(deps: IndexerDeps): Router {
       }
 
       // Count total results
-      const resultCount = (text.match(/<item>/g) || []).length;
+      const resultCount = (text.match(/<item[^>]*>/g) || []).length;
 
       res.json({
         success: true,
@@ -218,7 +218,7 @@ export function createIndexerRoutes(deps: IndexerDeps): Router {
 
       // Parse XML to extract titles from within <item> tags only
       const titles: string[] = [];
-      const itemMatches = text.matchAll(/<item>([\s\S]*?)<\/item>/g);
+      const itemMatches = text.matchAll(/<item[^>]*>([\s\S]*?)<\/item>/g);
 
       for (const itemMatch of itemMatches) {
         const itemContent = itemMatch[1];
@@ -229,7 +229,7 @@ export function createIndexerRoutes(deps: IndexerDeps): Router {
       }
 
       // Count total results
-      const resultCount = (text.match(/<item>/g) || []).length;
+      const resultCount = (text.match(/<item[^>]*>/g) || []).length;
 
       res.json({
         success: true,


### PR DESCRIPTION
## Summary

- Some indexers (especially when accessed via proxies like Zyclops/NZBHydra) return XML with namespace attributes on `<item>` tags, e.g. `<item xmlns:newznab="http://www.newznab.com/DTD/2010/feeds/attributes/">`.
- The test indexer routes (`/:name/test` and `/test-new`) use regex `/<item>` to parse results, which fails to match `<item xmlns:...>`, causing the test to report zero results even when the indexer returned valid data.
- Changed `/<item>` to `/<item[^>]*>` in all four regex patterns across both route handlers, so any attributes on the `<item>` tag are tolerated.

## Test plan

- [ ] Test an indexer that returns bare `<item>` tags -- should still work as before
- [ ] Test an indexer (or proxy like Zyclops) that returns `<item xmlns:newznab="...">` tags -- should now correctly report results instead of zero

🤖 Generated with [Claude Code](https://claude.com/claude-code)