### PR TITLE
Fix HTTP URLs returned behind reverse proxy

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -48,6 +48,7 @@ const { getRouter } = addonSDK;
 const PORT = process.env.PORT || 1337;
 
 const app = express();
+app.set('trust proxy', 1);
 
 // Middleware
 app.use(cors());


### PR DESCRIPTION
## Summary                                                                                                                                                                     
- Add `trust proxy` configuration to Express so `req.protocol` respects the `X-Forwarded-Proto` header from reverse proxies
- Fixes URLs in stream redirects and fallbacks being constructed as `http://` instead of `https://` when served behind a reverse proxy (e.g., Nginx, Caddy, Traefik)           
- This causes issues with clients that don't follow the `http://` → `https://` upgrade                                                                             
                                                                                                                                                                                 
## Details                                                                                                                                                                     
Four places construct URLs using `req.protocol`:                                                                                                                               
- `src/nzbdav/streamHandler.ts` (lines 438, 510, 534) — stream self-redirects and WebDAV proxy redirects
- `src/routes/nzbdav.ts` (line 669) — fallback redirect on 404                                                                                                                 
                                                                                                                                                                                 
Without `trust proxy`, Express ignores `X-Forwarded-Proto` and always returns `http` as the protocol, even when the reverse proxy terminates TLS.                              
                                                                                                                                                                                 
The fix is a single line: `app.set('trust proxy', 1)` — trust one proxy hop. This is safe for direct exposure (no proxy) since Express falls back to the actual connection protocol when the header is absent.